### PR TITLE
fix: drop pivot table first in migration rollback of roles and permission table

### DIFF
--- a/database/migrations/create_permissions_table.php.stub
+++ b/database/migrations/create_permissions_table.php.stub
@@ -42,7 +42,7 @@ return new class extends Migration
         $models = config('guard.models');
         $pivotTableName = Guard::getPivotTableName(Arr::only($models, ['role', 'permission']));
 
-        Schema::dropIfExists($tables['permissions']);
         Schema::dropIfExists($pivotTableName);
+        Schema::dropIfExists($tables['permissions']);
     }
 };

--- a/database/migrations/create_roles_table.php.stub
+++ b/database/migrations/create_roles_table.php.stub
@@ -42,7 +42,7 @@ return new class extends Migration
         $models = config('guard.models');
         $pivotTableName = Guard::getPivotTableName(Arr::only($models, ['role', 'user']));
 
-        Schema::dropIfExists($tables['roles']);
         Schema::dropIfExists($pivotTableName);
+        Schema::dropIfExists($tables['roles']);
     }
 };


### PR DESCRIPTION
When I run migrate:rollback I get error because current code trying to drop main table before dropping foreign key dependencies. After fix it will drop dependent tables first for both 'roles' and 'permissions' table